### PR TITLE
Update to 22.04.2

### DIFF
--- a/packer/ubuntu-server.pkr.hcl
+++ b/packer/ubuntu-server.pkr.hcl
@@ -5,7 +5,7 @@ variable "boot_wait" {
 
 variable "iso_checksum" {
   type    = string
-  default = "84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f"
+  default = "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931"
 }
 
 variable "iso_url" {

--- a/packer/ubuntu-server.pkr.hcl
+++ b/packer/ubuntu-server.pkr.hcl
@@ -10,7 +10,7 @@ variable "iso_checksum" {
 
 variable "iso_url" {
   type    = string
-  default = "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso"
+  default = "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso"
 }
 
 variable "cpus" {


### PR DESCRIPTION
The original ISO is not available:

https://releases.ubuntu.com/22.04/